### PR TITLE
Programmatic extensions of Active Record models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem 'pry'
   gem 'pry-rails'
   gem 'pry-byebug'
+  gem 'pry-doc'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,9 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
+    pry-doc (0.10.0)
+      pry (~> 0.9)
+      yard (~> 0.9)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (1.6.5)
@@ -169,6 +172,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    yard (0.9.8)
 
 PLATFORMS
   ruby
@@ -181,6 +185,7 @@ DEPENDENCIES
   mysql2 (~> 0.3.18)
   pry
   pry-byebug
+  pry-doc
   pry-rails
   rails (= 4.2.4)
   rspec-rails

--- a/app/models/composer.rb
+++ b/app/models/composer.rb
@@ -1,6 +1,14 @@
 class Composer < ActiveRecord::Base
   has_many :works
 
+  def self.sales_rankings
+    Hash.new(0).tap do |rankings|
+      Work.sales_rankings.map do |work,sales|
+        rankings[work.composer.id] += sales
+      end
+    end
+  end
+
   def editions
     works.map { |work| work.editions }.flatten.uniq
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -4,18 +4,70 @@ class Customer < ActiveRecord::Base
            dependent: :destroy
 
   def open_orders
-    orders.find(:all, conditions: "status = 'open'")
+    orders.where(status: 'open')
   end
 
   def editions_on_order
-    open_orders.map { |order| order.edition }.uniq
+    editions(open_orders)
   end
 
   def edition_history
-    orders.map { |order| order.edition }.uniq
+    editions(orders)
+  end
+
+  def work_history
+    works(edition_history)
   end
 
   def works_on_order
-    editions_on_order.flat_map { |edition| edition.works }.uniq
+    works(editions_on_order)
+  end
+
+  def composer_rankings
+    rank(comp_history)
+  end
+
+  def instrument_rankings
+    rank(instr_history)
+  end
+
+  def copies_of(edition)
+    orders.where(edition_id: edition.id).size
+  end
+
+  def balance
+    "%.2f" % open_orders.inject(0) do |acc,order|
+      acc + order.edition.price
+    end
+  end
+
+  def check_out
+    orders.each do |order|
+      order.upadte_attribute(:status, 'paid')
+    end
+  end
+
+  private
+
+  def comp_history
+    edition_history.flat_map { |edition| edition.composers }
+  end
+
+  def instr_history
+    work_history.flat_map { |work| work.instruments }
+  end
+
+  def rank(list)
+    list.uniq.sort_by do |i|
+      list.select { |instr| instr == i }.size
+    end
+  end
+
+  def editions(list)
+    list.map { |order| order.edition }.uniq
+  end
+
+  def works(list)
+    list.flat_map { |edition| edition.works }.uniq
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,9 +1,28 @@
 class Edition < ActiveRecord::Base
-  belongs_to :work
+
   belongs_to :publisher
   has_many :orders
+  has_and_belongs_to_many :works
 
   before_create do
     self.description = "standard" unless description
+  end
+
+  def self.of_works(works)
+    works.flat_map { |work| work.editions }.uniq
+  end
+
+  def composers
+    works.flat_map { |work| work.composer }.uniq
+  end
+
+  def nice_title
+    title_or_works_title + " (#{publisher.name}, #{year})"
+  end
+
+  private
+
+  def title_or_works_title
+    title || works.first.nice_title
   end
 end

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -1,5 +1,127 @@
 class Work < ActiveRecord::Base
+
+  ORDERED = %w{ flute oboe violin viola cello piano orchestra }
+  PERIODS = {
+    [1650..1750, %w{ EN DE FR IT ES NL }] => 'Baroque',
+    [1751..1810, %w{ EN IT DE NL }] => 'Classical',
+    [1751..1830, %w{ FR }] => 'Classical',
+    [1837..1901, %w{ EN }] => 'Victorian',
+    [1820..1897, %w{ DE FR }] => 'Romantic',
+  }
+
   belongs_to :composer
-  has_many :editions
-  has_and_belongs_to_many :instruments, order: "year ASC"
+  has_and_belongs_to_many :editions, order: 'year ASC'
+  has_and_belongs_to_many :instruments, order: 'year ASC'
+
+  def self.all_periods
+    all.flat_map { |work| work.period }.uniq.sort
+  end
+
+  def self.sales_rankings
+    Hash.new(0).tap do |rankings|
+      all.each do |work|
+        work.editions.each do |edition|
+          rankings[work.id] += edition.orders.size
+        end
+      end
+    end
+  end
+
+  def publishers
+    editions.map { |edition| edition.publisher }.uniq
+  end
+
+  def country
+    composer.country
+  end
+
+  def ordered_by
+    orders.map { |order| order.customers }.uniq
+  end
+
+  def key
+    kee
+  end
+
+  def nice_title
+    "#{title} #{key_str}#{nice_opus_str}#{nice_instr_str}"
+  end
+
+  def nice_instruments
+    case sorted_instrs.size
+    when 0
+      nil
+    when 1
+      sorted_instrs.first
+    when 2
+      sorted_instrs.join(' and ')
+    else
+      sorted_instrs[0..-2].join(', ') + ', and ' + sorted_instrs.last
+    end
+  end
+
+  def nice_opus
+    if /^\d/.match(opus)
+      "op. #{opus}"
+    else
+      opus
+    end
+  end
+
+  def period
+    PERIODS[pkey] || century
+  end
+
+  def century
+    cent + ordinal_indicator + ' century'
+  end
+
+  private
+
+  def orders
+    editions.flat_map { |edition| edition.orders }
+  end
+
+  def sorted_instrs
+    unsorted_instrs.sort_by { |i| ORDERED.index(i) || 0 }
+  end
+
+  def unsorted_instrs
+    instruments.map { |inst| inst.name }
+  end
+
+  def pkey
+    PERIODS.keys.find do |yrange,countries|
+      yrange.include?(year) && countries.include?(country)
+    end
+  end
+
+  def key_str
+    if key?
+      "in #{key}"
+    end
+  end
+
+  def nice_opus_str
+    if nice_opus
+      ", #{nice_opus}"
+    end
+  end
+
+  def nice_instr_str
+    if nice_instruments
+      ", for #{nice_instruments}"
+    end
+  end
+
+  def ordinal_indicator
+    case cent
+    when '21' then 'st'
+    else 'th'
+    end
+  end
+
+  def cent
+    (year - 1).to_s[0,2].succ
+  end
 end

--- a/db/migrate/20170302180344_remove_work_from_editions.rb
+++ b/db/migrate/20170302180344_remove_work_from_editions.rb
@@ -1,0 +1,5 @@
+class RemoveWorkFromEditions < ActiveRecord::Migration
+  def change
+    remove_reference :editions, :work, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20170302203029_create_join_table_editions_works.rb
+++ b/db/migrate/20170302203029_create_join_table_editions_works.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableEditionsWorks < ActiveRecord::Migration
+  def change
+    create_join_table :editions, :works do |t|
+      t.index [:edition_id, :work_id]
+      t.index [:work_id, :edition_id]
+    end
+  end
+end

--- a/db/migrate/20170302233847_add_year_to_works.rb
+++ b/db/migrate/20170302233847_add_year_to_works.rb
@@ -1,0 +1,5 @@
+class AddYearToWorks < ActiveRecord::Migration
+  def change
+    add_column :works, :year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170218220348) do
+ActiveRecord::Schema.define(version: 20170302233847) do
 
   create_table "composers", force: :cascade do |t|
     t.string   "first_name",  limit: 255
@@ -37,7 +37,6 @@ ActiveRecord::Schema.define(version: 20170218220348) do
     t.string   "description",  limit: 255
     t.integer  "year",         limit: 4
     t.float    "price",        limit: 24
-    t.integer  "work_id",      limit: 4
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "publisher_id", limit: 4
@@ -45,7 +44,14 @@ ActiveRecord::Schema.define(version: 20170218220348) do
   end
 
   add_index "editions", ["publisher_id"], name: "index_editions_on_publisher_id", using: :btree
-  add_index "editions", ["work_id"], name: "index_editions_on_work_id", using: :btree
+
+  create_table "editions_works", id: false, force: :cascade do |t|
+    t.integer "edition_id", limit: 4, null: false
+    t.integer "work_id",    limit: 4, null: false
+  end
+
+  add_index "editions_works", ["edition_id", "work_id"], name: "index_editions_works_on_edition_id_and_work_id", using: :btree
+  add_index "editions_works", ["work_id", "edition_id"], name: "index_editions_works_on_work_id_and_edition_id", using: :btree
 
   create_table "instruments", force: :cascade do |t|
     t.string   "name",       limit: 255
@@ -88,12 +94,12 @@ ActiveRecord::Schema.define(version: 20170218220348) do
     t.datetime "updated_at",              null: false
     t.string   "kee",         limit: 255
     t.string   "opus",        limit: 255
+    t.integer  "year",        limit: 4
   end
 
   add_index "works", ["composer_id"], name: "index_works_on_composer_id", using: :btree
 
   add_foreign_key "editions", "publishers"
-  add_foreign_key "editions", "works"
   add_foreign_key "orders", "customers"
   add_foreign_key "orders", "editions"
   add_foreign_key "works", "composers"


### PR DESCRIPTION
Based on chatper 15 of the book, Ruby for Rails. This chapter deals with programmatic extensions of Active Record models. In addition, added some additional structure to the database and pulled in pry-doc, for use with emacs' robe-mode.